### PR TITLE
Debug shell script bad substitution error

### DIFF
--- a/build_app.sh
+++ b/build_app.sh
@@ -27,8 +27,8 @@ while [[ $i -le $# ]]; do
 			;;
 		--project-path)
 			# Check if next argument exists and is not another flag
-			if [[ $((i+1)) -le $# ]] && [[ "${!((i+1))}" != -* ]]; then
-				PROJECT_PATH="${!((i+1))}"
+			if [[ $((i+1)) -le $# ]] && [[ "${@:$((i+1)):1}" != -* ]]; then
+				PROJECT_PATH="${@:$((i+1)):1}"
 				((i++))  # Skip the next argument since we consumed it
 			else
 				echo "ERROR: --project-path requires a path argument" >&2


### PR DESCRIPTION
Fix 'bad substitution' error in `build_app.sh` by correcting bash syntax for accessing positional parameters.

The original syntax `${!((i+1))}` is an invalid bash substitution. The change to `${@:$((i+1)):1}` correctly extracts the `(i+1)`-th argument from the list of all positional parameters (`$@`).

---
<a href="https://cursor.com/background-agent?bcId=bc-2996e936-90b4-4e91-a615-fec2771cd85a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2996e936-90b4-4e91-a615-fec2771cd85a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

